### PR TITLE
Fixed fraction of a second issues

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -37,6 +37,8 @@ func (task CronTask) ShouldRun(now time.Time) bool {
 	if err != nil {
 		return false
 	}
+	
+	now = now.Truncate(time.Second)
 
 	return schedule.IsWithin(now)
 }


### PR DESCRIPTION
A lot of the places this is used it's passing in fractions of a second that schedule.IsWithin(now) accepts and then fails to match it within the timeframe. 

So "* * * * *" would never run.

But "*/2 * * * *" would because it would get caught in the following minute.